### PR TITLE
Complete ADR-0018 workspace hygiene implementation

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Deny committing Home Assistant runtime state
+git diff --cached --name-only -z | tr '\0' '\n' | grep -E '^\.storage/' >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+  echo >&2 "ERROR: .storage/ contents are runtime state and must not be committed (ADR-0018)."
+  echo >&2 "Unstage with: git restore --staged .storage && retry."
+  exit 1
+fi
+exit 0

--- a/.github/adr0018_allowlist.txt
+++ b/.github/adr0018_allowlist.txt
@@ -1,0 +1,2 @@
+expires: 2025-10-27T00:00:00Z
+\.bak($|[.-])|\\.perlbak$|_backup($|[.-])|_restore($|[.-])

--- a/.github/workflows/adr-0018-extra-guards.yml
+++ b/.github/workflows/adr-0018-extra-guards.yml
@@ -1,0 +1,49 @@
+# topology: see workspace_ops_export.yaml
+name: ADR-0018 Extra Guards
+on:
+  pull_request: { branches: [ main ] }
+  push: { branches: [ main ] }
+  workflow_dispatch:
+
+jobs:
+  guards:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: ".storage hard-fail"
+        run: |
+          if git ls-files -z | tr '\0' '\n' | grep -E '^\.\storage/'; then
+            echo "::error::.storage/* is runtime state; refuse per ADR-0018"
+            exit 1
+          fi
+          echo "OK: no .storage tracked"
+
+      - name: "Ban tracked archives (tar.gz/tgz/zip/bundle)"
+        run: |
+          if git ls-files -z | tr '\0' '\n' | grep -Ei '\.(tar\.gz|tgz|zip|bundle)$'; then
+            echo "::error::Archive blobs must not be tracked (use _backups/ + manifests)"
+            exit 1
+          fi
+          echo "OK: no tracked archives"
+
+      - name: "Legacy backup allowlist (grace -> warn, post-expiry -> fail)"
+        run: |
+          FILE=".github/adr0018_allowlist.txt"
+          [ -f "$FILE" ] || { echo "no allowlist (skip)"; exit 0; }
+          EXPIRES=$(grep -i '^expires:' "$FILE" | awk '{print $2}' | tr -d '\r')
+          NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          echo "Allowlist expires: $EXPIRES (now=$NOW)"
+          PAT=$(grep -v -i '^expires:' "$FILE" | sed '/^\s*$/d')
+          if [ -z "$PAT" ]; then echo "empty allowlist"; exit 0; fi
+          # find tracked matches
+          MATCHES=$(git ls-files -z | tr '\0' '\n' | grep -E "$(printf '%s\n' "$PAT" | paste -sd'|' -)")
+          if [ -z "$MATCHES" ]; then echo "no legacy matches"; exit 0; fi
+          echo "$MATCHES" | sed 's/^/LEGACY: /'
+          # compare timestamps lexicographically (ISO8601 UTC)
+          if [ "$NOW" \> "$EXPIRES" ]; then
+            echo "::error::Legacy backup shapes found after grace expiry"
+            exit 1
+          else
+            echo "::warning::Legacy backup shapes allowed until $EXPIRES"
+          fi

--- a/.github/workflows/adr-frontmatter-verify.yml
+++ b/.github/workflows/adr-frontmatter-verify.yml
@@ -1,0 +1,18 @@
+# topology: see workspace_ops_export.yaml
+name: ADR Frontmatter Verify
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.11' }
+      - run: pip install pyyaml
+      - run: python hestia/tools/adr/verify_frontmatter.py

--- a/.github/workflows/adr_lint.yml
+++ b/.github/workflows/adr_lint.yml
@@ -1,3 +1,4 @@
+# topology: see workspace_ops_export.yaml
 name: ADR Lint
 
 on:

--- a/.github/workflows/deny-offer-lines.yml
+++ b/.github/workflows/deny-offer-lines.yml
@@ -1,3 +1,4 @@
+# topology: see workspace_ops_export.yaml
 name: deny-offer-lines
 on: [push, pull_request]
 jobs:

--- a/.github/workflows/guardrails-rest-command.yml
+++ b/.github/workflows/guardrails-rest-command.yml
@@ -1,3 +1,4 @@
+# topology: see workspace_ops_export.yaml
 name: Guardrails - REST command
 
 on:

--- a/.github/workflows/metadata-validate.yml
+++ b/.github/workflows/metadata-validate.yml
@@ -1,3 +1,4 @@
+# topology: see workspace_ops_export.yaml
 name: Validate metadata
 on:
   pull_request:

--- a/.github/workflows/rehydration-seed.yml
+++ b/.github/workflows/rehydration-seed.yml
@@ -1,3 +1,4 @@
+# topology: see workspace_ops_export.yaml
 name: Rehydration seed validation
 
 on:

--- a/.github/workflows/workspace-enforcer.yml
+++ b/.github/workflows/workspace-enforcer.yml
@@ -1,3 +1,4 @@
+# topology: see workspace_ops_export.yaml
 name: workspace-enforcer
 on: [pull_request]
 jobs:

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ hestia-adr-lint hestia/docs/ADR --format human
 ```
 
 Note: do not create venvs or caches under /n/ha or /config. The workflow and README instruct to create the venv under the user home.
+
+**Operational topology:** see `./workspace_ops_export.yaml`

--- a/hestia/docs/ADR/ADR-0019-remote-topology-mirror-policy.md
+++ b/hestia/docs/ADR/ADR-0019-remote-topology-mirror-policy.md
@@ -1,0 +1,124 @@
+---
+id: ADR-0019
+title: Remote Topology & Mirror Policy (GitHub ⇄ NAS ⇄ Local)
+status: proposed
+date: 2025-09-28
+author: e-app-404
+relates_to:
+  - ADR-0015  # Snapshots & inventory policy
+  - ADR-0017  # Branch rescue / rollback protocol
+  - ADR-0018  # Workspace lifecycle & CI guardrails
+---
+
+## Context
+We operate with:
+- **GitHub repo**: canonical "source of truth".
+- **NAS mirror** (`origin`): pull-through mirror + backup, served from Synology.
+- **Local worktrees**: developer machines.
+
+We already follow ADR-0017/0018 safety patterns (backup tags/branches, receipts, hygiene gate). This ADR consolidates the **remote topology, allowed flows, and recovery procedures**.
+
+## Decision
+1) **Source of truth** = `github/main`.  
+2) **NAS mirror** is **pull-only** (no dev pushes). It is updated by **fetching from GitHub**, not by direct developer force-pushes.  
+3) All risky ref moves (force updates, history surgery) **must**:
+   - create **backup branch + tag** first,
+   - be recorded with a **receipt** in `hestia/reports/<YYYYMMDD>/...`,
+   - follow ADR-0017 commands (one-at-a-time).
+4) CI gates (ADR-0018) are required on PRs into `main`:  
+   - `hygiene-gate / gate`  
+   - `ADR-0018 Extra Guards / guards`  
+   - `ADR Frontmatter Verify / verify`
+
+## Topology & Roles
+- **GitHub remote name:** `github` (read/write for maintainers).  
+- **NAS remote name:** `origin` (**read** for devs; **admin-managed write**).  
+- **Local:** developers create branches, push to **GitHub**, open PRs; mirror sync is **automated or admin-run**.
+
+## Normal Flow
+- Dev → **push branch to GitHub**, open PR → CI gates pass → **merge to `main`**.
+- Mirror sync (job or admin) runs:
+  ```bash
+  # on NAS host, in bare repo; run as repo owner (e.g., gituser)
+  git -C /volume1/git-mirrors/ha-config.git \
+    fetch --prune https://github.com/<org>/<repo>.git \
+    +refs/heads/main:refs/heads/main
+  ```
+- No direct developer push to `origin/main`.
+
+## Cutover / Force-Replace (rare)
+
+When we must replace `github/main` with a known-good branch:
+
+1. **Preflight (local)**:
+   ```bash
+   git status --porcelain
+   git fetch github main && git rev-parse github/main
+   ```
+
+2. **Back up current GitHub main**:
+   ```bash
+   STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+   git push github github/main:refs/heads/backup/main-$STAMP
+   git push github github/main:refs/tags/backup/main-$STAMP
+   ```
+
+3. **Publish our branch & replace main (with lease)**:
+   ```bash
+   git push github my/branch:my/branch
+   git push --force-with-lease=main github my/branch:main
+   ```
+
+4. **Receipt**: write a short receipt under `hestia/reports/<YYYYMMDD>/cutover_receipt_<TS>.txt`.
+
+5. **Mirror update (pull-through only)**:
+   - **Preferred**: NAS fetch from GitHub (same command as Normal Flow).
+   - **If fetch is blocked by perms**, NAS admin may run (in bare repo, as repo owner):
+     ```bash
+     GH_SHA=$(git ls-remote --heads https://github.com/<org>/<repo>.git main | awk '{print $1}')
+     git -C /volume1/git-mirrors/ha-config.git update-ref refs/heads/main "$GH_SHA"
+     ```
+   - **Never require developers to force-push to origin**.
+
+## Disaster Recovery
+- **Roll back GitHub main to a backup**:
+  ```bash
+  git push --force-with-lease=main github backup/main-<STAMP>:main
+  ```
+- **NAS mirror then fetches from GitHub to realign**.
+
+## Guardrails
+- **NAS perms**: the bare repo is owned by the service account (e.g., `gituser:users`), directories are `g+s`, and the repo path is in `safe.directory` for admin tasks.
+- **Branch Protection on GitHub main** requires:
+  - `hygiene-gate / gate`
+  - `ADR-0018 Extra Guards / guards`
+  - `ADR Frontmatter Verify / verify`
+- **Pre-commit hook** denies staging `.storage/**` and other ADR-0018 banned paths.
+- **Receipts** (text, tiny) are allowed in Git to explain cutovers.
+
+## Consequences
+- **Clear ownership**: GitHub is canonical; NAS is backup/distribution.
+- **Lower risk during cutovers**; easy rollbacks via backup branches/tags.
+- **Auditable** via receipts & CI gates.
+
+## Appendix — One-at-a-time Command Cards
+
+**A) Verify triad alignment**
+```bash
+git rev-parse HEAD
+git ls-remote --heads github main | awk '{print $1}'
+git ls-remote --heads origin main | awk '{print $1}'
+```
+
+**B) Seed CI status context on main**
+```bash
+git switch main
+git pull --ff-only github main
+git commit --allow-empty -m "ci(hygiene): seed"
+git push github main
+```
+
+**C) Mirror health (NAS host)**
+```bash
+git -C /volume1/git-mirrors/ha-config.git show-ref refs/heads/main
+```

--- a/hestia/tools/adr/verify_frontmatter.py
+++ b/hestia/tools/adr/verify_frontmatter.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import pathlib
+import sys
+
+import yaml
+
+REQ = {"id","title","status","date"}
+ROOT = pathlib.Path("hestia/docs/ADR")
+
+def check(p: pathlib.Path):
+    s = p.read_text(errors="ignore")
+    if not s.startswith("---"):
+        return (False, "missing frontmatter fence")
+    try:
+        block = s.split("---", 2)[1]
+        fm = yaml.safe_load(block) or {}
+    except Exception as e:
+        return (False, f"frontmatter parse error: {e}")
+    missing = REQ - set(map(str.lower, fm.keys()))
+    return (len(missing)==0, f"missing: {', '.join(sorted(missing))}" if missing else "ok")
+
+def main():
+    paths = sorted(ROOT.glob("ADR-*.md"))
+    if not paths:
+        print("NO_ADRS")
+        return 0
+    bad = []
+    for p in paths:
+        ok, why = check(p)
+        print(f"{'OK' if ok else 'FAIL'} {p} {why}")
+        if not ok: bad.append(p)
+    return 1 if bad else 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hestia/tools/utils/legacy_backup_renamer.py
+++ b/hestia/tools/utils/legacy_backup_renamer.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import argparse
+import datetime
+import os
+import pathlib
+import re
+import shutil
+import sys
+
+ROOT = pathlib.Path(".").resolve()
+
+SKIP_DIRS = {".git", ".storage", "_backups/inventory", ".venv", "node_modules", "__pycache__", ".mypy_cache", ".ruff_cache"}
+LEGACY_RX = re.compile(r"""
+    (\.bak(\b|$|\-|\.\d)|\.perlbak$|_backup(\b|$)|_restore(\b|$))
+""", re.IGNORECASE | re.VERBOSE)
+
+def is_skipped(path: pathlib.Path) -> bool:
+    parts = set(path.parts)
+    return any(s in parts for s in SKIP_DIRS)
+
+def to_canonical(p: pathlib.Path) -> pathlib.Path:
+    utc = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    stem, ext = p.stem, p.suffix
+    # collapse multiple legacy tokens into one .bk.<UTC> before extension
+    base = re.sub(LEGACY_RX, "", p.name)
+    if ext:
+        if not LEGACY_RX.search(p.name):
+            name = f"{p.stem}.bk.{utc}{ext}"
+        else:
+            name = f"{re.sub(LEGACY_RX,'',p.stem)}.bk.{utc}{ext}"
+    else:
+        name = f"{re.sub(LEGACY_RX,'',p.name)}.bk.{utc}"
+    name = name.replace("..", ".").strip(".")
+    return p.with_name(name)
+
+def main():
+    ap = argparse.ArgumentParser(description="Normalize legacy backup names to *.bk.<UTC> (dry-run by default)")
+    ap.add_argument("--apply", action="store_true", help="perform renames")
+    ap.add_argument("--root", default=".", help="scan root (default: current repo root)")
+    ap.add_argument("--tag", default="", help="annotative tag printed in output (no functional effect)")
+    args = ap.parse_args()
+
+    changes = []
+    root = pathlib.Path(args.root).resolve()
+    for d, _, files in os.walk(root):
+        dpath = pathlib.Path(d)
+        if is_skipped(dpath.relative_to(root)): 
+            continue
+        for f in files:
+            p = dpath / f
+            if LEGACY_RX.search(p.name):
+                dst = to_canonical(p)
+                if dst.name != p.name:
+                    changes.append((p, dst))
+
+    for src, dst in changes:
+        rels = src.relative_to(root)
+        reld = dst.relative_to(root)
+        print(f"FOUND{f'[{args.tag}]' if args.tag else ''}\t{rels} -> {reld}")
+    if not args.apply:
+        print(f"DRYRUN total={len(changes)}")
+        return 0
+
+    # apply
+    for src, dst in changes:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if dst.exists():
+            # if content identical, remove src; else append suffix
+            if src.read_bytes() == dst.read_bytes():
+                src.unlink()
+                print(f"DEDUP\t{src}")
+            else:
+                dup_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+                with_suffix = dst.with_name(dst.stem + ".dup." + dup_time + dst.suffix)
+                shutil.move(str(src), str(with_suffix))
+                print(f"RENAMED_DUP\t{src} -> {with_suffix}")
+        else:
+            shutil.move(str(src), str(dst))
+            print(f"RENAMED\t{src} -> {dst}")
+    print(f"APPLY total={len(changes)}")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hestia/tools/utils/reportkit/compact_index.py
+++ b/hestia/tools/utils/reportkit/compact_index.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+import argparse
+import datetime as dt
+import hashlib
+import pathlib
+import sys
+
+
+def sha(s: bytes) -> str: return hashlib.sha256(s).hexdigest()
+
+def main():
+    ap = argparse.ArgumentParser(description="Compact _backups/inventory/_index.jsonl by age")
+    ap.add_argument("--keep-days", type=int, default=30)
+    ap.add_argument("--dir", default="_backups/inventory")
+    args = ap.parse_args()
+
+    inv = pathlib.Path(args.dir)
+    idx = inv / "_index.jsonl"
+    arch = inv / "_index.archive.jsonl"
+
+    if not idx.exists():
+        print("NOINDEX (nothing to compact)")
+        return 0
+
+    cutoff = dt.datetime.utcnow() - dt.timedelta(days=args.keep_days)
+    keep, move = [], []
+
+    with idx.open("rb") as f:
+        for line in f:
+            # best effort: find an ISO timestamp in the line; fallback keep
+            try:
+                s = line.decode("utf-8", "ignore")
+                # crude parse: look for 20-char UTC ISO or our UTC stamps
+                t = None
+                for token in s.split():
+                    token = token.strip().strip('",')
+                    for fmt in ("%Y-%m-%dT%H:%M:%SZ","%Y%m%dT%H%M%SZ"):
+                        try:
+                            t = dt.datetime.strptime(token, fmt)
+                            break
+                        except: pass
+                    if t: break
+                if t and t < cutoff:
+                    move.append(line)
+                else:
+                    keep.append(line)
+            except Exception:
+                keep.append(line)
+
+    # dedup archive by sha
+    arch_shas = set()
+    if arch.exists():
+        with arch.open("rb") as f:
+            for l in f:
+                arch_shas.add(sha(l))
+
+    added = 0
+    if move:
+        with arch.open("ab") as f:
+            for l in move:
+                h = sha(l)
+                if h in arch_shas: continue
+                f.write(l)
+                added += 1
+    with idx.open("wb") as f:
+        f.writelines(keep)
+
+    print(f"COMPACT keep={len(keep)} moved={len(move)} added_to_archive={added}")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hestia/tools/utils/reportkit/link_latest.py
+++ b/hestia/tools/utils/reportkit/link_latest.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import pathlib
+import sys
+
+root = pathlib.Path("hestia/reports")
+if not root.exists():
+    print("NOREPORTS")
+    sys.exit(0)
+
+candidates=[]
+for day in sorted(root.glob("[0-9]"*8)):
+    for batch in day.glob("*__*"):
+        if batch.is_dir(): candidates.append(batch)
+if not candidates:
+    print("NO_BATCHES")
+    sys.exit(0)
+
+latest = max(candidates, key=lambda p: p.stat().st_mtime)
+link = root / "latest"
+try:
+    if link.exists() or link.is_symlink():
+        link.unlink()
+    link.symlink_to(latest.relative_to(root))
+    print(f"LATEST -> {latest}")
+except OSError:
+    # FS without symlinks: write a text pointer instead
+    with open(root / "latest.path", "w") as f:
+        f.write(str(latest)+"\n")
+    print(f"LATEST_FILE -> {latest}")

--- a/workspace_ops_export.yaml
+++ b/workspace_ops_export.yaml
@@ -1,0 +1,579 @@
+# Operational topology configuration for LLM assistants
+# Access patterns: prefer ./workspace_ops_export.yaml; fallback to /config/hestia/core/config/workspace_ops_export.yaml
+# Discovery: `git ls-files workspace_ops_export.yaml` or see README.md reference
+# Versioning: update via PR; includes last_updated field for staleness detection
+# Remote topology policy: see ADR-0019 (GitHub ⇄ NAS ⇄ Local topology & mirror flows)
+last_updated: "2025-09-28T11:30:00Z"
+
+workspaces:
+  - name: "HA Config"
+    purpose: "config"
+    default_branch: "main"
+    branch_model: "trunk"
+    remotes:
+      primary_push: "ssh://gituser@192.168.0.104/volume1/git-mirrors/ha-config.git"
+      additional:
+        - name: "origin"
+          url: "ssh://gituser@192.168.0.104/volume1/git-mirrors/ha-config.git"
+          role: "push"
+          push_refspecs: ["+refs/heads/main:refs/heads/main", "+refs/tags/*:refs/tags/*"]
+        - name: "tailnet"
+          url: "ssh://gituser@100.93.61.53/volume1/git-mirrors/ha-config.git"
+          role: "fetch-only"
+          push_refspecs: []
+    network:
+      lan_ip: "192.168.0.104"
+      tailnet_ip: "100.93.61.53"
+      synology_git_shell_wrapped: true
+      nas_hostnames: ["ds220plus.reverse-beta.ts.net", "100.93.61.53"]
+    governance:
+      protected_branches: ["main"]
+      pr_checks_required: ["hardcoded-ha-guard"]
+      commit_signing_required: false
+    files:
+      expects_large_binaries: false
+      git_lfs_needed: false
+      allows_symlinks: false
+    lfs:
+      pinned_to: "none"
+      lfs_url: "-"
+      track_patterns: []
+    ci_cd:
+      platform: "github-actions"
+      workflows:
+        - name: "hardcoded-ha-guard"
+          path: ".github/workflows/hardcoded-ha-guard.yml"
+    hooks:
+      pre_commit:
+        enabled: true
+        runs: ["hestia/tools/validators/scan_hardcoded_ha.sh"]
+    mirror_policy:
+      nas_path: "/volume1/git-mirrors/ha-config.git"
+      push_refs: ["main", "tags"]
+      runner: "self-hosted-lan"
+      adr_reference: "ADR-0019"  # Remote topology & mirror policy
+    env_template:
+      path: ".env.sample"
+      vars:
+        HA_MOUNT: "${HA_MOUNT:-$HOME/hass}"
+        HA_MOUNT_OPERATOR: "/Volumes/HA"
+    vscode_samples:
+      paths: [".vscode-configs/config-lean.sample.code-workspace"]
+    required_secrets: []
+    common_commands:
+      list:
+        - desc: "Validate no hard-coded /n/ha outside docs"
+          cmd: "bash hestia/tools/validators/scan_hardcoded_ha.sh"
+        - desc: "Push main + tags to NAS mirror"
+          cmd: "git push origin main --tags"
+    troubleshooting:
+      entries:
+        - symptom: "ssh: Could not resolve hostname ds220plus..."
+          cause: "Tailnet DNS/host offline or Tailscale not running"
+          fix: "Use Tailnet IP (100.93.61.53) or ensure Tailscale is up and host online"
+        - symptom: "fatal: git package does not support customized git-shell-commands"
+          cause: "Synology git-shell wrapper rejects remote shell commands"
+          fix: "Push to a bare repo path only; avoid invoking remote shell commands; verify repo path & permissions"
+    notes: "ADR-0016 references workspace sample; .vscode-configs/README explains usage. Tailnet remote is fetch-only by policy."
+
+  - name: "HA BB-8 Add-on"
+    purpose: "addon"
+    default_branch: "main"
+    branch_model: "trunk"
+    remotes:
+      primary_push: "ssh://gituser@ds220plus.reverse-beta.ts.net/volume1/git-mirrors/ha-config.git"
+      additional:
+        - name: "origin"
+          url: "ssh://gituser@ds220plus.reverse-beta.ts.net/volume1/git-mirrors/ha-config.git"
+          role: "push"
+          push_refspecs: ["+refs/heads/main:refs/heads/main", "+refs/tags/*:refs/tags/*"]
+        # Optional GitHub remote to add via setup steps (kept out of current state to avoid assumptions)
+        # - name: "github"
+        #   url: "https://github.com/e-app-404/ha-bb8-addon"
+        #   role: "push"
+        #   push_refspecs: ["+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*"]
+    network:
+      lan_ip: "192.168.0.0/24"
+      tailnet_ip: "-"
+      synology_git_shell_wrapped: true
+      nas_hostnames: ["ds220plus.reverse-beta.ts.net"]
+    governance:
+      protected_branches: ["main"]
+      pr_checks_required: ["lint", "tests", "guardrails/index-regeneration", "guard-size-symlinks"]
+      commit_signing_required: false
+    files:
+      expects_large_binaries: false
+      git_lfs_needed: false
+      allows_symlinks: false
+    lfs:
+      pinned_to: "none"
+      lfs_url: "-"
+      track_patterns: []
+    ci_cd:
+      platform: "github-actions"
+      workflows:
+        - name: "guard-size-symlinks"
+          path: ".github/workflows/guard-size-symlinks.yml"
+    hooks:
+      pre_commit:
+        enabled: true
+        runs: ["ops/validators/guard_size_symlinks.sh"]
+    mirror_policy:
+      nas_path: "/volume1/git-mirrors/ha-config.git"
+      push_refs: ["main", "tags"]
+      runner: "-"
+      adr_reference: "ADR-0019"  # Remote topology & mirror policy
+    env_template:
+      path: "-"
+      vars: {}
+    vscode_samples:
+      paths: []
+    required_secrets: []
+    common_commands:
+      list:
+        - desc: "Validate size/symlink guard locally"
+          cmd: "bash ops/validators/guard_size_symlinks.sh"
+        - desc: "Add GitHub remote (optional)"
+          cmd: "git remote add github https://github.com/e-app-404/ha-bb8-addon 2>/dev/null || git remote set-url github https://github.com/e-app-404/ha-bb8-addon"
+    troubleshooting:
+      entries:
+        - symptom: "Commit blocked: tracked symlink detected"
+          cause: "Pre-commit guard caught a symlink in index"
+          fix: "Remove symlink or .gitignore it; commit regular files only"
+        - symptom: "PR not created via gh"
+          cause: "GitHub CLI not authenticated or remote not pointing to GitHub"
+          fix: "Run `gh auth login` and ensure a `github` remote exists"
+    notes: "`origin` points to HA Config NAS mirror for backup only; PRs should target a GitHub remote when added. Guard blocks tracked symlinks and >50MB files."
+
+  - name: "Omega Registry"
+    purpose: "addon+registry"
+    default_branch: "main"
+    branch_model: "trunk"
+    remotes:
+      primary_push: "https://github.com/e-app-404/omega_registry.git"
+      additional:
+        - name: "origin"
+          url: "ssh://gituser@ds220plus.reverse-beta.ts.net/volume1/git/omega_registry.git"
+          role: "mirror"
+          push_refspecs: ["+refs/heads/main:refs/heads/main", "+refs/tags/*:refs/tags/*"]
+        - name: "github"
+          url: "https://github.com/e-app-404/omega_registry.git"
+          role: "push"
+          push_refspecs: ["+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*"]
+    network:
+      lan_ip: "192.168.0.104"
+      tailnet_ip: "100.x.y.z"
+      synology_git_shell_wrapped: true
+      nas_hostnames: ["ds220plus.reverse-beta.ts.net", "100.x.y.z"]
+    governance:
+      protected_branches: ["main", "chore/restructure-to-addon"]
+      pr_checks_required: ["validate-adrs", "ruff"]
+      commit_signing_required: false
+    files:
+      expects_large_binaries: true
+      git_lfs_needed: true
+      allows_symlinks: false
+    lfs:
+      pinned_to: "github"
+      lfs_url: "https://github.com/e-app-404/omega_registry.git/info/lfs"
+      track_patterns: ["*.json", "*.jsonl", "*.bin", "*.tar.gz", "*.zip"]
+    ci_cd:
+      platform: "github-actions"
+      workflows:
+        - name: "mirror-to-nas"
+          path: ".github/workflows/mirror-to-nas.yml"
+          gated_secret: "NAS_SSH_KEY"
+        - name: "validate-adrs"
+          path: ".github/workflows/validate-adrs.yml"
+    hooks:
+      pre_commit:
+        enabled: false
+        runs: []
+    mirror_policy:
+      nas_path: "/volume1/git/omega_registry.git"
+      push_refs: ["main", "tags"]
+      runner: "github-hosted"
+      adr_reference: "ADR-0019"  # Remote topology & mirror policy
+    env_template:
+      path: "-"
+      vars: {}
+    vscode_samples:
+      paths: []
+    required_secrets: ["NAS_SSH_KEY"]
+    common_commands:
+      list:
+        - desc: "Create safety bundle"
+          cmd: "git bundle create ../omega_registry-before-lfs-pin.bundle --all"
+        - desc: "Push feature branch to GitHub"
+          cmd: "git push -u github $(git rev-parse --abbrev-ref HEAD)"
+    troubleshooting:
+      entries:
+        - symptom: "GitHub push rejected (GH013: push protection: secrets)"
+          cause: "Secret-like strings detected in commit history/files"
+          fix: "Remove/redact tokens or create a clean branch containing only non-sensitive changes; then push"
+        - symptom: "Mirror job times out"
+          cause: "NAS unreachable from GitHub-hosted runners"
+          fix: "Use self-hosted runner on LAN/Tailnet or expose NAS over reachable address; ensure NAS_SSH_KEY is configured"
+    notes: "LFS pinned to GitHub; NAS is a mirror via workflow gated by NAS_SSH_KEY."
+
+embed_files:
+  # --- BB-8 Add-on & (optionally) Omega: size/symlink guard ---
+  - path: "ops/validators/guard_size_symlinks.sh"
+    mode: "755"
+    content: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      thresh=$((50*1024*1024))
+      mode="local"; [ "${CI:-}" = "true" ] && mode="ci"
+      fail(){ printf '%s\n' "$*" >&2; exit 1; }
+
+      # Detect tracked symlinks (index-mode)
+      BAD_SYMS=$(git ls-files -s | awk '$1 ~ /^120/ {print $4}')
+      if [ -n "${BAD_SYMS}" ]; then
+        fail "ERROR: symlinks tracked in Git:\n${BAD_SYMS}"
+      fi
+
+      # Build diff command (NUL-delimited)
+      declare -a DIFF_CMD
+      if [ "$mode" = "local" ]; then
+        DIFF_CMD=(git diff --cached --name-only --diff-filter=AM -z)
+      else
+        if [ -n "${GITHUB_BASE_REF:-}" ]; then
+          git fetch origin "$GITHUB_BASE_REF" --depth=1 || true
+          DIFF_CMD=(git diff --name-only "origin/${GITHUB_BASE_REF}"...HEAD -z)
+        else
+          git fetch origin main --depth=1 || true
+          DIFF_CMD=(git diff --name-only origin/main...HEAD -z)
+        fi
+      fi
+
+      tmpf=$(mktemp)
+      if ! "${DIFF_CMD[@]}" >"$tmpf" 2>/dev/null || [ ! -s "$tmpf" ]; then
+        src_cmd=(git ls-files -z)
+      else
+        src_cmd=(cat "$tmpf")
+      fi
+
+      ok=1
+      # shellcheck disable=SC2094
+      while IFS= read -r -d '' f; do
+        [ -f "$f" ] || continue
+        sz=$(wc -c < "$f")
+        if [ "$sz" -gt "$thresh" ]; then
+          printf 'ERROR: Large file (>50MB): %s (%d bytes)\n' "$f" "$sz" >&2
+          ok=0
+        fi
+      done < <("${src_cmd[@]}")
+
+      rm -f "$tmpf"
+      [ "$ok" -eq 1 ] && echo "OK: size/symlink guard passed" || exit 3
+
+  - path: ".github/workflows/guard-size-symlinks.yml"
+    content: |
+      name: Guard size/symlinks
+      on: [push, pull_request]
+      jobs:
+        guard:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v4
+              with:
+                fetch-depth: 0
+                fetch-tags: true
+            - name: Run size/symlink validator
+              run: bash ops/validators/guard_size_symlinks.sh
+
+  # --- Omega Registry only: NAS mirror workflow + LFS pin ---
+  - path: ".github/workflows/mirror-to-nas.yml"
+    content: |
+      name: Mirror main + tags to NAS
+      on:
+        push:
+          branches: [ main ]
+        workflow_dispatch: {}
+      jobs:
+        mirror:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v4
+              with:
+                fetch-depth: 0
+                fetch-tags: true
+            - name: Load NAS deploy key
+              if: ${{ secrets.NAS_SSH_KEY }}
+              uses: webfactory/ssh-agent@v0.8.0
+              with:
+                ssh-private-key: ${{ secrets.NAS_SSH_KEY }}
+            - name: Preflight: check NAS reachability
+              if: ${{ secrets.NAS_SSH_KEY }}
+              env:
+                GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10"
+              run: |
+                ssh -o BatchMode=yes gituser@ds220plus.reverse-beta.ts.net 'echo OK_NAS'
+            - name: Push to NAS
+              if: ${{ secrets.NAS_SSH_KEY }}
+              env:
+                NAS_URL: "ssh://gituser@ds220plus.reverse-beta.ts.net/volume1/git/omega_registry.git"
+                GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10"
+              run: |
+                git remote add nas "$NAS_URL" || true
+                git push nas main --tags
+                echo "Pushed main + tags to NAS"
+                git ls-remote nas refs/heads/main refs/tags/* | sed -n '1,50p' || true
+            - name: Note if disabled
+              if: ${{ !secrets.NAS_SSH_KEY }}
+              run: echo "NAS mirror disabled (missing NAS_SSH_KEY secret)."
+
+  - path: ".lfsconfig"
+    content: |
+      [lfs]
+        url = https://github.com/e-app-404/omega_registry.git/info/lfs
+
+  - path: ".gitattributes"
+    content: |
+      # ----- BEGIN LFS DEFAULTS (Omega Registry) -----
+      *.json filter=lfs diff=lfs merge=lfs -text
+      *.jsonl filter=lfs diff=lfs merge=lfs -text
+      *.bin filter=lfs diff=lfs merge=lfs -text
+      *.tar.gz filter=lfs diff=lfs merge=lfs -text
+      *.zip filter=lfs diff=lfs merge=lfs -text
+      # ----- END LFS DEFAULTS -----
+
+  # --- HA Config only: hard-coded /n/ha guard + template env ---
+  - path: "hestia/tools/validators/scan_hardcoded_ha.sh"
+    mode: "755"
+    content: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      have_rg() { command -v rg >/dev/null 2>&1; }
+      if have_rg; then
+        rg -n --hidden --glob '!.git' --glob '!hestia/docs/**' \
+           --glob '!**/*.png' --glob '!**/*.jpg' --glob '!**/*.jpeg' \
+           --glob '!**/*.gif' --glob '!**/*.svg' \
+           '/n/ha' . \
+           && { echo "ERROR: hard-coded /n/ha found outside docs"; exit 1; } \
+           || { echo "OK: no hard-coded /n/ha outside docs"; }
+      else
+        MATCHES=$(grep -R -n --exclude-dir=".git" --exclude-dir="hestia/docs" \
+          --exclude="*.png" --exclude="*.jpg" --exclude="*.jpeg" --exclude="*.gif" --exclude="*.svg" \
+          '/n/ha' . || true)
+        if [ -n "$MATCHES" ]; then echo "$MATCHES"; echo "ERROR: hard-coded /n/ha found outside docs"; exit 1; fi
+        echo "OK: no hard-coded /n/ha outside docs"
+      fi
+
+  - path: ".github/workflows/hardcoded-ha-guard.yml"
+    content: |
+      name: Hardcoded /n/ha guard
+      on: [push, pull_request]
+      jobs:
+        scan:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v4
+              with:
+                fetch-depth: 0
+            - name: Run validator
+              run: bash hestia/tools/validators/scan_hardcoded_ha.sh
+
+  - path: ".env.sample"
+    content: |
+      # Copy to .env and adjust locally as needed.
+      export HA_MOUNT="${HA_MOUNT:-$HOME/hass}"
+      export HA_MOUNT_OPERATOR="/Volumes/HA"
+      export CONFIG_MOUNT="$HA_MOUNT/config"
+      export DIR_HESTIA="$CONFIG_MOUNT/hestia"
+      export DIR_PACKAGES="$CONFIG_MOUNT/packages"
+      export DIR_DOMAINS="$CONFIG_MOUNT/domain"
+
+  - path: ".vscode-configs/config-lean.sample.code-workspace"
+    content: |
+      {
+        "folders": [ { "path": "." } ],
+        "settings": {
+          "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+          "git.repositoryScanIgnoredFolders": ["${workspaceFolder}/share"]
+        }
+      }
+
+  - path: ".vscode-configs/README.md"
+    content: |
+      # VS Code samples
+      Use `config-lean.sample.code-workspace` by opening it in VS Code and saving a local copy as `.vscode/config-lean.code-workspace`. Keep editor-specific settings untracked.
+
+idempotent_setup:
+  - workspace: "HA Config"
+    steps: |
+      set -euo pipefail
+      git rev-parse --is-inside-work-tree >/dev/null
+      cd "$(git rev-parse --show-toplevel)"
+      git switch -c chore/parameterize-ha-mount || git switch chore/parameterize-ha-mount
+      mkdir -p hestia/tools/validators .github/workflows .vscode-configs
+      # Write/update files explicitly for HA Config
+      cat > hestia/tools/validators/scan_hardcoded_ha.sh <<'SH'
+      #!/usr/bin/env bash
+      set -euo pipefail
+      have_rg() { command -v rg >/dev/null 2>&1; }
+      if have_rg; then
+        rg -n --hidden --glob '!.git' --glob '!hestia/docs/**' --glob '!**/*.png' --glob '!**/*.jpg' --glob '!**/*.jpeg' --glob '!**/*.gif' --glob '!**/*.svg' '/n/ha' . \
+        && { echo "ERROR: hard-coded /n/ha found outside docs"; exit 1; } \
+        || { echo "OK: no hard-coded /n/ha outside docs"; }
+      else
+        MATCHES=$(grep -R -n --exclude-dir=".git" --exclude-dir="hestia/docs" --exclude="*.png" --exclude="*.jpg" --exclude="*.jpeg" --exclude="*.gif" --exclude="*.svg" '/n/ha' . || true)
+        if [ -n "$MATCHES" ]; then echo "$MATCHES"; echo "ERROR: hard-coded /n/ha found outside docs"; exit 1; fi
+        echo "OK: no hard-coded /n/ha outside docs"
+      fi
+      SH
+      chmod +x hestia/tools/validators/scan_hardcoded_ha.sh
+      cat > .github/workflows/hardcoded-ha-guard.yml <<'YML'
+      name: Hardcoded /n/ha guard
+      on: [push, pull_request]
+      jobs:
+        scan:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v4
+              with: { fetch-depth: 0 }
+            - run: bash hestia/tools/validators/scan_hardcoded_ha.sh
+      YML
+      cat > .env.sample <<'ENV'
+      export HA_MOUNT="${HA_MOUNT:-$HOME/hass}"
+      export HA_MOUNT_OPERATOR="/Volumes/HA"
+      export CONFIG_MOUNT="$HA_MOUNT/config"
+      export DIR_HESTIA="$CONFIG_MOUNT/hestia"
+      export DIR_PACKAGES="$CONFIG_MOUNT/packages"
+      export DIR_DOMAINS="$CONFIG_MOUNT/domain"
+      ENV
+      git add hestia/tools/validators/scan_hardcoded_ha.sh .github/workflows/hardcoded-ha-guard.yml .env.sample || true
+      git commit -m "chore(guard): add hard-coded /n/ha validator + CI" || true
+      # Ensure tailnet remote is fetch-only
+      git remote add tailnet ssh://gituser@100.93.61.53/volume1/git-mirrors/ha-config.git 2>/dev/null || true
+      git remote set-url --push tailnet no_push://disabled 2>/dev/null || true
+
+  - workspace: "HA BB-8 Add-on"
+    steps: |
+      set -euo pipefail
+      git rev-parse --is-inside-work-tree >/dev/null
+      cd "$(git rev-parse --show-toplevel)"
+      git switch -c chore/guard-size-symlinks || git switch chore/guard-size-symlinks
+      mkdir -p ops/validators .github/workflows
+      # Validator (explicitly write)
+      cat > ops/validators/guard_size_symlinks.sh <<'SH'
+      #!/usr/bin/env bash
+      set -euo pipefail
+      thresh=$((50*1024*1024)); mode="local"; [ "${CI:-}" = "true" ] && mode="ci"
+      BAD_SYMS=$(git ls-files -s | awk '$1 ~ /^120/ {print $4}'); [ -n "$BAD_SYMS" ] && { echo -e "ERROR: symlinks tracked in Git:\n$BAD_SYMS" >&2; exit 1; }
+      if [ "$mode" = "local" ]; then DIFF_CMD=(git diff --cached --name-only --diff-filter=AM -z); else if [ -n "${GITHUB_BASE_REF:-}" ]; then git fetch origin "$GITHUB_BASE_REF" --depth=1 || true; DIFF_CMD=(git diff --name-only "origin/${GITHUB_BASE_REF}"...HEAD -z); else git fetch origin main --depth=1 || true; DIFF_CMD=(git diff --name-only origin/main...HEAD -z); fi; fi
+      tmpf=$(mktemp); if ! "${DIFF_CMD[@]}" >"$tmpf" 2>/dev/null || [ ! -s "$tmpf" ]; then src_cmd=(git ls-files -z); else src_cmd=(cat "$tmpf"); fi
+      ok=1; while IFS= read -r -d '' f; do [ -f "$f" ] || continue; sz=$(wc -c < "$f"); [ "$sz" -gt $((50*1024*1024)) ] && { echo "ERROR: Large file (>50MB): $f ($sz bytes)" >&2; ok=0; }; done < <("${src_cmd[@]}"); rm -f "$tmpf"; [ "$ok" -eq 1 ] && echo "OK: size/symlink guard passed" || exit 3
+      SH
+      chmod +x ops/validators/guard_size_symlinks.sh
+      cat > .github/workflows/guard-size-symlinks.yml <<'YML'
+      name: Guard size/symlinks
+      on: [push, pull_request]
+      jobs:
+        guard:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v4
+              with: { fetch-depth: 0, fetch-tags: true }
+            - run: bash ops/validators/guard_size_symlinks.sh
+      YML
+      # Install local pre-commit (backup existing)
+      mkdir -p .git/hooks
+      if [ -f .git/hooks/pre-commit ]; then mv .git/hooks/pre-commit ".git/hooks/pre-commit.bak.$(date +%s)"; fi
+      printf '#!/usr/bin/env bash\nset -e\nbash ops/validators/guard_size_symlinks.sh\n' > .git/hooks/pre-commit
+      chmod +x .git/hooks/pre-commit
+      git add ops/validators/guard_size_symlinks.sh .github/workflows/guard-size-symlinks.yml || true
+      git commit -m "guardrails: size/symlink pre-commit + CI" || true
+      # Optionally add GitHub remote (no push if unreachable)
+      git remote add github https://github.com/e-app-404/ha-bb8-addon 2>/dev/null || git remote set-url github https://github.com/e-app-404/ha-bb8-addon
+
+  - workspace: "Omega Registry"
+    steps: |
+      set -euo pipefail
+      git rev-parse --is-inside-work-tree >/dev/null
+      cd "$(git rev-parse --show-toplevel)"
+      git bundle create ../omega_registry-before-lfs-pin.bundle --all || true
+      BR=chore/lfs-pin-and-mirror
+      git show-ref --quiet refs/heads/$BR && git switch "$BR" || git switch -c "$BR"
+      git lfs install --local
+      mkdir -p .github/workflows
+      cat > .lfsconfig <<'CFG'
+      [lfs]
+        url = https://github.com/e-app-404/omega_registry.git/info/lfs
+      CFG
+      if ! grep -q "BEGIN LFS DEFAULTS" .gitattributes 2>/dev/null; then
+        cat >> .gitattributes <<'ATTR'
+      # ----- BEGIN LFS DEFAULTS (Omega Registry) -----
+      *.json filter=lfs diff=lfs merge=lfs -text
+      *.jsonl filter=lfs diff=lfs merge=lfs -text
+      *.bin filter=lfs diff=lfs merge=lfs -text
+      *.tar.gz filter=lfs diff=lfs merge=lfs -text
+      *.zip filter=lfs diff=lfs merge=lfs -text
+      # ----- END LFS DEFAULTS -----
+      ATTR
+      fi
+      cat > .github/workflows/mirror-to-nas.yml <<'YML'
+      name: Mirror main + tags to NAS
+      on: { push: { branches: [ main ] }, workflow_dispatch: {} }
+      jobs:
+        mirror:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v4
+              with: { fetch-depth: 0, fetch-tags: true }
+            - if: ${{ secrets.NAS_SSH_KEY }}
+              uses: webfactory/ssh-agent@v0.8.0
+              with: { ssh-private-key: ${{ secrets.NAS_SSH_KEY }} }
+            - name: Preflight: check NAS reachability
+              if: ${{ secrets.NAS_SSH_KEY }}
+              env: { GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10" }
+              run: ssh -o BatchMode=yes gituser@ds220plus.reverse-beta.ts.net 'echo OK_NAS'
+            - name: Push to NAS
+              if: ${{ secrets.NAS_SSH_KEY }}
+              env:
+                NAS_URL: ssh://gituser@ds220plus.reverse-beta.ts.net/volume1/git/omega_registry.git
+                GIT_SSH_COMMAND: ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10
+              run: |
+                git remote add nas "$NAS_URL" || true
+                git push nas main --tags
+                git ls-remote nas refs/heads/main refs/tags/* | sed -n '1,50p' || true
+            - name: Note if disabled
+              if: ${{ !secrets.NAS_SSH_KEY }}
+              run: echo "NAS mirror disabled (missing NAS_SSH_KEY)."
+      YML
+      git add .lfsconfig .gitattributes .github/workflows/mirror-to-nas.yml || true
+      if [ -n "$(git status --porcelain)" ]; then git commit -m "chore(omega): pin LFS to GitHub + NAS mirror workflow (key-gated)"; else echo "No changes"; fi
+      git remote add github https://github.com/e-app-404/omega_registry.git 2>/dev/null || git remote set-url github https://github.com/e-app-404/omega_registry.git
+      git remote add origin ssh://gituser@ds220plus.reverse-beta.ts.net/volume1/git/omega_registry.git 2>/dev/null || true
+      git config --unset-all remote.origin.push || true
+      git config --add remote.origin.push "+refs/heads/main:refs/heads/main"
+      git config --add remote.origin.push "+refs/tags/*:refs/tags/*"
+      if git ls-remote --exit-code github HEAD >/dev/null 2>&1; then git push -u github "$BR"; else echo "GitHub unreachable; skip push." >&2; fi
+
+acceptance_checklist:
+  - workspace: "HA Config"
+    checks:
+      - "git rev-parse --abbrev-ref HEAD"
+      - "git ls-files .env.sample hestia/tools/validators/scan_hardcoded_ha.sh .github/workflows/hardcoded-ha-guard.yml"
+      - "bash hestia/tools/validators/scan_hardcoded_ha.sh"
+      - "git remote -v | sed -n '1,50p'"
+  - workspace: "HA BB-8 Add-on"
+    checks:
+      - "git rev-parse --abbrev-ref HEAD"
+      - "git ls-files ops/validators/guard_size_symlinks.sh .github/workflows/guard-size-symlinks.yml"
+      - "bash ops/validators/guard_size_symlinks.sh"
+      - "[ -x .git/hooks/pre-commit ] && echo 'pre-commit installed' || echo 'missing pre-commit'"
+  - workspace: "Omega Registry"
+    checks:
+      - "git rev-parse --abbrev-ref HEAD"
+      - "git ls-files .lfsconfig .gitattributes .github/workflows/mirror-to-nas.yml"
+      - "git lfs env | sed -n '1,40p'"
+      - "git ls-remote github HEAD || true"
+
+constraints:
+  - "Never include secrets or private keys in files or YAML. Reference secret names only (e.g., NAS_SSH_KEY)."
+  - "No destructive operations: no force-push to main, no history rewrite in these scripts."
+  - "Filename-safe scanning everywhere (NUL-delimited diffs; no whitespace breakage)."
+  - "CI jobs use fetch-depth: 0 and fetch-tags: true when diffs/tags are required."
+  - "Tailnet hosts may be unreachable from public CI; prefer self-hosted runner for NAS mirroring if needed."


### PR DESCRIPTION
• Add ADR-0019: Remote topology & mirror policy (GitHub ⇄ NAS ⇄ Local) • Add workspace_ops_export.yaml: Complete operational topology for LLM assistants • Implement ADR-0018 hardening tools:
  - Legacy backup renamer with grace period allowlist
  - Report index compactor and latest batch linker
  - ADR frontmatter verifier
  - Pre-commit hook to deny .storage/ tracking
  - Hygiene and bundle scripts for workspace maintenance • Add CI workflows:
  - ADR frontmatter verification
  - ADR-0018 extra guards with grace period logic • Update README with operational topology reference • Establish GitHub as canonical source per ADR-0019

Resolves comprehensive workspace lifecycle governance per ADR-0018. Establishes proper remote topology per ADR-0019.